### PR TITLE
Widen chimera bowden holes for collet clips

### DIFF
--- a/he_mount_generator.scad
+++ b/he_mount_generator.scad
@@ -486,7 +486,7 @@ xMountHoleHeightOffset = (xMountHeight - (xMountHoleHeight /2));
 chiColdHeight = 30;
 chiColdDepth = 16;
 chiScrewHole = 3.2; // Size of hole for screws that mount the Chimera Cold End.
-chiBowdenHole = 8.2; // Size of hole for bowden tube fittings.
+chiBowdenHole = 9.0; // Size of hole for bowden tube fittings.
 chiHEPosUD = (carriage == "prusai3" ? 15 : 20);
 chiBraceLength = chiColdDepth; // Length of brace for chimera mount in the horizontal. From back plane towards the front.
 chiBraceHeight = (chiColdHeight / 2) - (carriage == "prusai3" ? (chiHEPosUD - (chiColdHeight / 2) < xMountCornerRadius ? xMountCornerRadius - (chiHEPosUD - (chiColdHeight / 2)) : 0) : 0);


### PR DESCRIPTION
Widening this hole allows for a collet clip (such as https://www.thingiverse.com/thing:2585970) to fit.

I was unable to use the normal method of pushing the tube in, then lifting the collet to lock the bowden tube into place because it was very difficult to bolt the chimera into place without the mount point pushing one of the collets down. The increase in hole diameter will make that easier or allow for the collet clip to be sure.